### PR TITLE
fix: improve Landlock sandbox failure messaging

### DIFF
--- a/docs/provider-codex.md
+++ b/docs/provider-codex.md
@@ -162,6 +162,12 @@ controlled by sandbox policies. Use `skip_permissions: true` (maps to
 `--yolo`) for full access, or the default `--full-auto` for workspace-
 scoped writes.
 
+### "error applying legacy Linux sandbox restrictions: Sandbox(LandlockRestrict)"
+
+This indicates Codex could not initialize Landlock on the current host.
+Run in a Landlock-compatible environment, or set `skip_permissions: true`
+for trusted environments where `--yolo` is acceptable.
+
 ### System prompt not taking effect
 
 Codex does not have a `--append-system-prompt` flag. System prompts

--- a/koan/app/cli_errors.py
+++ b/koan/app/cli_errors.py
@@ -25,6 +25,11 @@ class ErrorCategory(Enum):
     UNKNOWN = "unknown"
 
 
+_LANDLOCK_PATTERNS = [
+    r"LandlockRestrict",
+    r"legacy\s+Linux\s+sandbox\s+restrictions",
+]
+
 # Patterns indicating transient server/network errors (worth retrying).
 # Matched case-insensitively against combined stdout+stderr.
 _RETRYABLE_PATTERNS = [
@@ -63,6 +68,22 @@ _TERMINAL_PATTERNS = [
 
 _RETRYABLE_RE = re.compile("|".join(_RETRYABLE_PATTERNS), re.IGNORECASE)
 _TERMINAL_RE = re.compile("|".join(_TERMINAL_PATTERNS), re.IGNORECASE)
+_LANDLOCK_RE = re.compile("|".join(_LANDLOCK_PATTERNS), re.IGNORECASE)
+
+
+def is_landlock_failure(stdout: str = "", stderr: str = "") -> bool:
+    """Return True when output matches known Landlock sandbox startup failures."""
+    return bool(_LANDLOCK_RE.search(f"{stdout}\n{stderr}"))
+
+
+def build_landlock_hint() -> str:
+    """Return user-facing remediation hint for Landlock sandbox failures."""
+    return (
+        "Landlock sandbox initialization failed. "
+        "If this host does not support Landlock, run in a compatible "
+        "environment or enable `skip_permissions: true` for Codex "
+        "(trusted environments only)."
+    )
 
 
 def classify_cli_error(

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -199,6 +199,21 @@ def build_full_command(
     )
 
 
+def _raise_cli_invocation_error(stderr: str = "", stdout: str = "") -> None:
+    """Raise RuntimeError with user-facing hints for known CLI failure classes."""
+    from app.cli_errors import build_landlock_hint, is_landlock_failure
+
+    if is_landlock_failure(stdout=stdout, stderr=stderr):
+        print(
+            "[provider] Raw CLI Landlock failure details:\n"
+            f"{stdout}\n{stderr}",
+            file=sys.stderr,
+        )
+        raise RuntimeError(f"CLI invocation failed: {build_landlock_hint()}")
+
+    raise RuntimeError(f"CLI invocation failed: {stderr[:300]}")
+
+
 def run_command(
     prompt: str,
     project_path: str,
@@ -236,8 +251,9 @@ def run_command(
     )
 
     if result.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {result.stderr[:300]}"
+        _raise_cli_invocation_error(
+            stderr=result.stderr or "",
+            stdout=result.stdout or "",
         )
 
     from app.claude_step import strip_cli_noise
@@ -305,9 +321,7 @@ def run_command_streaming(
 
     stdout_text = "\n".join(lines)
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {stderr_text[:300]}"
-        )
+        _raise_cli_invocation_error(stderr=stderr_text, stdout=stdout_text)
 
     # Notify user when max turns ceiling was hit so they know how to raise it
     import re

--- a/koan/tests/test_cli_errors.py
+++ b/koan/tests/test_cli_errors.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from app.cli_errors import ErrorCategory, classify_cli_error
+from app.cli_errors import (
+    ErrorCategory,
+    build_landlock_hint,
+    classify_cli_error,
+    is_landlock_failure,
+)
 
 
 class TestClassifyCliError:
@@ -157,3 +162,25 @@ class TestClassifyCliError:
         stderr = "Error: Invalid API key provided. Check your ANTHROPIC_API_KEY."
         result = classify_cli_error(1, stderr=stderr)
         assert result == ErrorCategory.TERMINAL
+
+
+class TestLandlockDetection:
+    """Landlock-specific detection helpers."""
+
+    def test_detects_landlock_restrict_error(self):
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        assert is_landlock_failure(stderr=stderr) is True
+
+    def test_detects_landlock_in_stdout(self):
+        assert is_landlock_failure(stdout="Sandbox(LandlockRestrict)") is True
+
+    def test_returns_false_for_other_errors(self):
+        assert is_landlock_failure(stderr="connection reset by peer") is False
+
+    def test_landlock_hint_mentions_skip_permissions(self):
+        hint = build_landlock_hint()
+        assert "skip_permissions: true" in hint
+        assert "Landlock sandbox initialization failed" in hint

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -1059,6 +1059,28 @@ class TestRunCommand:
                 allowed_tools=["Read"],
             )
 
+    @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "codex"})
+    @patch("app.cli_exec.run_cli")
+    @patch("app.config.get_model_config", return_value={"chat": "gpt-5-codex", "fallback": ""})
+    def test_landlock_failure_shows_hint_and_logs_raw_error(
+        self, mock_models, mock_run, capsys
+    ):
+        """Landlock startup failure gets actionable hint and raw debug output."""
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+        with pytest.raises(RuntimeError, match="Landlock sandbox initialization failed"):
+            run_command(
+                prompt="analyze this",
+                project_path="/fake/project",
+                allowed_tools=["Read"],
+            )
+        captured = capsys.readouterr()
+        assert "Raw CLI Landlock failure details" in captured.err
+        assert "Sandbox(LandlockRestrict)" in captured.err
+
     @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "claude"})
     @patch("app.cli_exec.run_cli")
     @patch("app.config.get_model_config", return_value={"chat": "sonnet", "fallback": "haiku"})


### PR DESCRIPTION
## What
Add Landlock-specific CLI failure detection and show an actionable operator hint instead of a generic invocation error.

## Why
Codex sandbox initialization failures on some Linux hosts are easy to misread as generic execution failures, which slows remediation.

## How
- Added Landlock failure detection helpers in `app/cli_errors.py`.
- Routed provider CLI failure handling through a shared helper that:
  - logs raw stdout/stderr to debug output for Landlock failures,
  - raises a clearer user-facing remediation message.
- Added a Codex troubleshooting note for the Landlock error signature.
- Added regression tests for detection and message/log behavior.

## Testing
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_cli_errors.py koan/tests/test_cli_provider.py -q`
- Result: `207 passed`

Closes #6
