### PR TITLE
fix: reduce codex formatter fallback noise

### DIFF
--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -26,6 +26,53 @@ from app.language_preference import get_language_instruction
 from app.config import get_model_config
 from app.response_cache import get_format_cache
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_ERROR_KEYWORD_RE = re.compile(
+    r"error|failed|exception|denied|unauthorized|forbidden|timeout|"
+    r"timed out|invalid|landlock|sandbox|quota|rate limit|"
+    r"connection reset|connection refused|econnreset|econnrefused",
+    re.IGNORECASE,
+)
+
+
+def _is_cli_noise_line(line: str) -> bool:
+    """Return True when a stderr line looks like provider banner/metadata noise."""
+    lower = line.lower().strip()
+    if not lower:
+        return True
+
+    metadata_prefixes = (
+        "openai codex",
+        "model:",
+        "provider:",
+        "workspace:",
+        "cwd:",
+        "session:",
+        "trace id:",
+        "telemetry:",
+        "thinking...",
+    )
+    if lower.startswith(metadata_prefixes):
+        return True
+
+    # Decorative separators / box-drawing from CLI wrappers.
+    return bool(re.fullmatch(r"[\s=\-─│┌┐└┘├┤┬┴┼•·]+", line))
+
+
+def summarize_cli_error(stderr: str, max_chars: int = 200) -> str:
+    """Extract a concise, actionable stderr summary for fallback logs."""
+    cleaned = _ANSI_ESCAPE_RE.sub("", stderr or "")
+    lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
+    if not lines:
+        return "no stderr output"
+
+    meaningful = [line for line in lines if not _is_cli_noise_line(line)]
+    candidates = meaningful or lines
+    keyword_hits = [line for line in candidates if _ERROR_KEYWORD_RE.search(line)]
+    selected = keyword_hits[:2] if keyword_hits else candidates[-2:]
+    summary = " | ".join(selected)
+    return summary if len(summary) <= max_chars else summary[:max_chars - 3] + "..."
+
 
 def load_soul(instance_dir: Path) -> str:
     """Load Kōan's identity from soul.md.
@@ -203,7 +250,12 @@ def format_message(raw_content: str, soul: str, prefs: str,
         else:
             # Fallback: if Claude fails, return truncated raw content
             # Don't cache fallback results
-            print(f"[format_outbox] Claude formatting failed: {result.stderr[:200]}", file=sys.stderr)
+            error_excerpt = summarize_cli_error(result.stderr or "")
+            print(
+                f"[format_outbox] Claude formatting failed (rc={result.returncode}): "
+                f"{error_excerpt}",
+                file=sys.stderr,
+            )
             return fallback_format(raw_content)
 
     except subprocess.TimeoutExpired:

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -12,6 +12,7 @@ from app.format_outbox import (
     load_memory_context,
     format_message,
     fallback_format,
+    summarize_cli_error,
 )
 from app.response_cache import _format_cache
 
@@ -109,6 +110,24 @@ class TestFormatForTelegram:
         # Should use fallback (removes #)
         assert "#" not in result
         assert "Raw content" in result
+
+    @patch("app.cli_exec.run_cli")
+    def test_nonzero_returncode_logs_compact_actionable_error(self, mock_run, capsys):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "OpenAI Codex v0.27.0\n"
+                "model: gpt-5-codex\n"
+                "workspace: /tmp/koan\n"
+                "RuntimeError: permission denied for sandbox profile\n"
+            ),
+        )
+        format_message("raw", "soul", "")
+        captured = capsys.readouterr()
+        assert "rc=1" in captured.err
+        assert "permission denied for sandbox profile" in captured.err
+        assert "OpenAI Codex v0.27.0" not in captured.err
 
     @patch("app.cli_exec.run_cli")
     def test_fallback_on_empty_stdout(self, mock_run):
@@ -259,6 +278,21 @@ class TestGetTimeHint:
             mock_dt.now.return_value = fake
             result = _get_time_hint()
         assert "late night" in result.lower()
+
+
+class TestSummarizeCliError:
+    def test_prefers_keyword_lines_and_removes_noise(self):
+        stderr = (
+            "OpenAI Codex v0.27.0\n"
+            "model: gpt-5-codex\n"
+            "workspace: /tmp/koan\n"
+            "Connection reset by peer\n"
+            "request failed with HTTP 502\n"
+        )
+        summary = summarize_cli_error(stderr)
+        assert "HTTP 502" in summary
+        assert "Connection reset" in summary
+        assert "OpenAI Codex" not in summary
 
 
 class TestFormatOutboxCLI:


### PR DESCRIPTION
## What
Reduce formatter fallback log noise by summarizing CLI stderr before logging fallback errors.

## Why
Issue #3 reports Codex fallback paths emitting banner/metadata noise that obscures the actionable failure signal.

## How
Added a stderr summarizer in `format_outbox` that strips ANSI and common banner/metadata lines, then keeps keyword-rich error lines.
Updated fallback logging to include return code plus concise excerpt instead of raw `stderr[:200]`.
Added regression tests for compact Codex-noise logging and keyword-prioritized summaries.

## Testing
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_format_outbox.py koan/tests/test_notify.py -q` (pass)
- `make test` (1 unrelated failure: `tests/test_reset_parser.py::TestParseResetTimeEdgeCases::test_us_timezone` due missing `tzdata` in environment)