### PR TITLE
fix: avoid /api/plans crash on config lookup

### DIFF
--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -1083,10 +1083,18 @@ def _parse_plan_progress(markdown: str) -> dict:
 
 def _get_project_repo(project_name: str) -> str | None:
     """Return owner/repo string for a project, or None if not available."""
-    from app.projects_config import get_project_config
+    from app.projects_config import get_project_config, load_projects_config
     from app.github_url_parser import parse_github_url
 
-    config = get_project_config(str(KOAN_ROOT), project_name)
+    try:
+        projects_config = load_projects_config(str(KOAN_ROOT))
+    except (ValueError, OSError):
+        return None
+
+    if not isinstance(projects_config, dict):
+        return None
+
+    config = get_project_config(projects_config, project_name)
     github_url = config.get("github_url", "")
     if not github_url:
         return None

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -1132,6 +1132,21 @@ class TestPlansPage:
         data = resp.get_json()
         assert data["plans"] == []
 
+    def test_api_plans_uses_projects_config_without_crashing(self, app_client):
+        """Regression: /api/plans should not 500 when resolving github_url from config."""
+        projects_cfg = {
+            "projects": {
+                "myproject": {"github_url": "https://github.com/owner/repo"}
+            }
+        }
+        with patch("app.utils.get_known_projects", return_value=[("myproject", "/path")]), \
+             patch("app.projects_config.load_projects_config", return_value=projects_cfg), \
+             patch("app.github.run_gh", return_value="[]"):
+            resp = app_client.get("/api/plans")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["plans"] == []
+
     def test_api_plans_skips_projects_without_github_url(self, app_client):
         with patch("app.utils.get_known_projects", return_value=[("myproject", "/some/path")]), \
              patch("app.dashboard._get_project_repo", return_value=None):


### PR DESCRIPTION
What: Fix `/api/plans` project repo resolution so it reads `projects.yaml` correctly instead of passing a string where a config mapping is expected.

Why: Issue #14 reports a 500 on `/api/plans` caused by `AttributeError: 'str' object has no attribute 'get'`, which breaks the Plans dashboard view.

How:
- Updated `_get_project_repo()` in `dashboard.py` to call `load_projects_config(KOAN_ROOT)` and pass the parsed dict into `get_project_config()`.
- Added defensive handling for config load failures (`ValueError`/`OSError`) and missing config mapping so the endpoint degrades safely.
- Added a regression test that exercises `/api/plans` without mocking `_get_project_repo`, proving the endpoint no longer crashes.

Testing:
- `KOAN_ROOT=/tmp/test-koan pytest koan/tests/test_dashboard.py -q`
- `KOAN_ROOT=/tmp/test-koan pytest koan/tests/test_projects_config.py -q`

Closes #14