### PR TITLE
fix: consolidate landlock messaging and Codex provider docs

### DIFF
--- a/docs/provider-codex.md
+++ b/docs/provider-codex.md
@@ -162,6 +162,12 @@ controlled by sandbox policies. Use `skip_permissions: true` (maps to
 `--yolo`) for full access, or the default `--full-auto` for workspace-
 scoped writes.
 
+### "error applying legacy Linux sandbox restrictions: Sandbox(LandlockRestrict)"
+
+This indicates Codex could not initialize Landlock on the current host.
+Run in a Landlock-compatible environment, or set `skip_permissions: true`
+for trusted environments where `--yolo` is acceptable.
+
 ### System prompt not taking effect
 
 Codex does not have a `--append-system-prompt` flag. System prompts

--- a/koan/app/cli_errors.py
+++ b/koan/app/cli_errors.py
@@ -25,6 +25,11 @@ class ErrorCategory(Enum):
     UNKNOWN = "unknown"
 
 
+_LANDLOCK_PATTERNS = [
+    r"LandlockRestrict",
+    r"legacy\s+Linux\s+sandbox\s+restrictions",
+]
+
 # Patterns indicating transient server/network errors (worth retrying).
 # Matched case-insensitively against combined stdout+stderr.
 _RETRYABLE_PATTERNS = [
@@ -63,6 +68,22 @@ _TERMINAL_PATTERNS = [
 
 _RETRYABLE_RE = re.compile("|".join(_RETRYABLE_PATTERNS), re.IGNORECASE)
 _TERMINAL_RE = re.compile("|".join(_TERMINAL_PATTERNS), re.IGNORECASE)
+_LANDLOCK_RE = re.compile("|".join(_LANDLOCK_PATTERNS), re.IGNORECASE)
+
+
+def is_landlock_failure(stdout: str = "", stderr: str = "") -> bool:
+    """Return True when output matches known Landlock sandbox startup failures."""
+    return bool(_LANDLOCK_RE.search(f"{stdout}\n{stderr}"))
+
+
+def build_landlock_hint() -> str:
+    """Return user-facing remediation hint for Landlock sandbox failures."""
+    return (
+        "Landlock sandbox initialization failed. "
+        "If this host does not support Landlock, run in a compatible "
+        "environment or enable `skip_permissions: true` for Codex "
+        "(trusted environments only)."
+    )
 
 
 def classify_cli_error(

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -20,10 +20,13 @@ Package structure:
     provider/__init__.py     — Registry, resolution, convenience functions
 """
 
+import logging
 import os
 import subprocess
 import sys
 from typing import List, Optional
+
+log = logging.getLogger(__name__)
 
 # Re-export base class and constants for convenience
 from app.provider.base import (  # noqa: F401
@@ -199,6 +202,33 @@ def build_full_command(
     )
 
 
+def _raise_cli_invocation_error(stderr: str = "", stdout: str = "") -> None:
+    """Raise RuntimeError with user-facing hints for known CLI failure classes."""
+    from app.cli_errors import build_landlock_hint, is_landlock_failure
+
+    if is_landlock_failure(stdout=stdout, stderr=stderr):
+        log.debug(
+            "[provider] Landlock failure details (stdout=%r, stderr=%r)",
+            stdout[:500] if stdout else "",
+            stderr[:500] if stderr else "",
+        )
+        raise RuntimeError(f"CLI invocation failed: {build_landlock_hint()}")
+
+    # For non-Landlock failures, include both stderr and stdout (when available)
+    # in the error message, truncated to keep the exception message concise.
+    stderr_str = stderr or ""
+    stdout_str = stdout or ""
+
+    message_parts = []
+    if stderr_str.strip():
+        message_parts.append("stderr:\n" + stderr_str.strip())
+    if stdout_str.strip():
+        message_parts.append("stdout:\n" + stdout_str.strip())
+
+    combined_message = " | ".join(message_parts) if message_parts else "no output captured"
+    truncated_message = combined_message[:300]
+
+    raise RuntimeError(f"CLI invocation failed: {truncated_message}")
 def run_command(
     prompt: str,
     project_path: str,
@@ -236,8 +266,9 @@ def run_command(
     )
 
     if result.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {result.stderr[:300]}"
+        _raise_cli_invocation_error(
+            stderr=result.stderr or "",
+            stdout=result.stdout or "",
         )
 
     from app.claude_step import strip_cli_noise
@@ -305,9 +336,7 @@ def run_command_streaming(
 
     stdout_text = "\n".join(lines)
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {stderr_text[:300]}"
-        )
+        _raise_cli_invocation_error(stderr=stderr_text, stdout=stdout_text)
 
     # Notify user when max turns ceiling was hit so they know how to raise it
     import re

--- a/koan/tests/test_cli_errors.py
+++ b/koan/tests/test_cli_errors.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from app.cli_errors import ErrorCategory, classify_cli_error
+from app.cli_errors import (
+    ErrorCategory,
+    build_landlock_hint,
+    classify_cli_error,
+    is_landlock_failure,
+)
 
 
 class TestClassifyCliError:
@@ -157,3 +162,25 @@ class TestClassifyCliError:
         stderr = "Error: Invalid API key provided. Check your ANTHROPIC_API_KEY."
         result = classify_cli_error(1, stderr=stderr)
         assert result == ErrorCategory.TERMINAL
+
+
+class TestLandlockDetection:
+    """Landlock-specific detection helpers."""
+
+    def test_detects_landlock_restrict_error(self):
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        assert is_landlock_failure(stderr=stderr) is True
+
+    def test_detects_landlock_in_stdout(self):
+        assert is_landlock_failure(stdout="Sandbox(LandlockRestrict)") is True
+
+    def test_returns_false_for_other_errors(self):
+        assert is_landlock_failure(stderr="connection reset by peer") is False
+
+    def test_landlock_hint_mentions_skip_permissions(self):
+        hint = build_landlock_hint()
+        assert "skip_permissions: true" in hint
+        assert "Landlock sandbox initialization failed" in hint

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -1051,13 +1051,42 @@ class TestRunCommand:
     @patch("app.config.get_model_config", return_value={"chat": "sonnet", "fallback": "haiku"})
     def test_failure_raises_runtime_error(self, mock_models, mock_run):
         """Non-zero exit raises RuntimeError with stderr snippet."""
-        mock_run.return_value = MagicMock(returncode=1, stderr="some error message")
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="some error message")
         with pytest.raises(RuntimeError, match="CLI invocation failed"):
             run_command(
                 prompt="analyze this",
                 project_path="/fake/project",
                 allowed_tools=["Read"],
             )
+
+    @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "codex"})
+    @patch("app.cli_exec.run_cli")
+    @patch("app.config.get_model_config", return_value={"chat": "gpt-5-codex", "fallback": ""})
+    def test_landlock_failure_shows_hint_and_logs_raw_error(
+        self, mock_models, mock_run
+    ):
+        """Landlock startup failure gets actionable hint and raw debug output."""
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+        with patch("app.provider.log") as mock_log:
+            with pytest.raises(RuntimeError, match="Landlock sandbox initialization failed"):
+                run_command(
+                    prompt="analyze this",
+                    project_path="/fake/project",
+                    allowed_tools=["Read"],
+                )
+            mock_log.debug.assert_called_once()
+            call_args = mock_log.debug.call_args
+            # Verify structured format: format string + positional stdout/stderr args
+            fmt_string = call_args.args[0]
+            assert "stdout=%r" in fmt_string
+            assert "stderr=%r" in fmt_string
+            # Verify the stderr content is passed as the second positional arg (truncated to 500)
+            logged_stderr = call_args.args[2]
+            assert logged_stderr == stderr[:500]
 
     @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "claude"})
     @patch("app.cli_exec.run_cli")


### PR DESCRIPTION
This PR creates a clean best-of merge of prior work from #7 and #12.

Included:
- Landlock failure messaging improvements
- Refinement from raw print(...) to logging.debug(...) for Landlock diagnostics
- Updated provider/tests aligned with the logging-based behavior
- docs/provider-codex.md update kept with runtime/provider changes

Why:
- Keep a single reviewable branch with the refined implementation and matching tests/docs, without extra branch history noise.
