### PR TITLE
fix: consolidate Codex provider hardening

### DIFF
--- a/docs/provider-codex.md
+++ b/docs/provider-codex.md
@@ -162,6 +162,12 @@ controlled by sandbox policies. Use `skip_permissions: true` (maps to
 `--yolo`) for full access, or the default `--full-auto` for workspace-
 scoped writes.
 
+### "error applying legacy Linux sandbox restrictions: Sandbox(LandlockRestrict)"
+
+This indicates Codex could not initialize Landlock on the current host.
+Run in a Landlock-compatible environment, or set `skip_permissions: true`
+for trusted environments where `--yolo` is acceptable.
+
 ### System prompt not taking effect
 
 Codex does not have a `--append-system-prompt` flag. System prompts

--- a/koan/app/cli_errors.py
+++ b/koan/app/cli_errors.py
@@ -25,6 +25,11 @@ class ErrorCategory(Enum):
     UNKNOWN = "unknown"
 
 
+_LANDLOCK_PATTERNS = [
+    r"LandlockRestrict",
+    r"legacy\s+Linux\s+sandbox\s+restrictions",
+]
+
 # Patterns indicating transient server/network errors (worth retrying).
 # Matched case-insensitively against combined stdout+stderr.
 _RETRYABLE_PATTERNS = [
@@ -63,6 +68,22 @@ _TERMINAL_PATTERNS = [
 
 _RETRYABLE_RE = re.compile("|".join(_RETRYABLE_PATTERNS), re.IGNORECASE)
 _TERMINAL_RE = re.compile("|".join(_TERMINAL_PATTERNS), re.IGNORECASE)
+_LANDLOCK_RE = re.compile("|".join(_LANDLOCK_PATTERNS), re.IGNORECASE)
+
+
+def is_landlock_failure(stdout: str = "", stderr: str = "") -> bool:
+    """Return True when output matches known Landlock sandbox startup failures."""
+    return bool(_LANDLOCK_RE.search(f"{stdout}\n{stderr}"))
+
+
+def build_landlock_hint() -> str:
+    """Return user-facing remediation hint for Landlock sandbox failures."""
+    return (
+        "Landlock sandbox initialization failed. "
+        "If this host does not support Landlock, run in a compatible "
+        "environment or enable `skip_permissions: true` for Codex "
+        "(trusted environments only)."
+    )
 
 
 def classify_cli_error(

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -26,6 +26,53 @@ from app.language_preference import get_language_instruction
 from app.config import get_model_config
 from app.response_cache import get_format_cache
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_ERROR_KEYWORD_RE = re.compile(
+    r"error|failed|exception|denied|unauthorized|forbidden|timeout|"
+    r"timed out|invalid|landlock|sandbox|quota|rate limit|"
+    r"connection reset|connection refused|econnreset|econnrefused",
+    re.IGNORECASE,
+)
+
+
+def _is_cli_noise_line(line: str) -> bool:
+    """Return True when a stderr line looks like provider banner/metadata noise."""
+    lower = line.lower().strip()
+    if not lower:
+        return True
+
+    metadata_prefixes = (
+        "openai codex",
+        "model:",
+        "provider:",
+        "workspace:",
+        "cwd:",
+        "session:",
+        "trace id:",
+        "telemetry:",
+        "thinking...",
+    )
+    if lower.startswith(metadata_prefixes):
+        return True
+
+    # Decorative separators / box-drawing from CLI wrappers.
+    return bool(re.fullmatch(r"[\s=\-─│┌┐└┘├┤┬┴┼•·]+", line))
+
+
+def summarize_cli_error(stderr: str, max_chars: int = 200) -> str:
+    """Extract a concise, actionable stderr summary for fallback logs."""
+    cleaned = _ANSI_ESCAPE_RE.sub("", stderr or "")
+    lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
+    if not lines:
+        return "no stderr output"
+
+    meaningful = [line for line in lines if not _is_cli_noise_line(line)]
+    candidates = meaningful or lines
+    keyword_hits = [line for line in candidates if _ERROR_KEYWORD_RE.search(line)]
+    selected = keyword_hits[:2] if keyword_hits else candidates[-2:]
+    summary = " | ".join(selected)
+    return summary if len(summary) <= max_chars else summary[:max_chars - 3] + "..."
+
 
 def load_soul(instance_dir: Path) -> str:
     """Load Kōan's identity from soul.md.
@@ -203,7 +250,12 @@ def format_message(raw_content: str, soul: str, prefs: str,
         else:
             # Fallback: if Claude fails, return truncated raw content
             # Don't cache fallback results
-            print(f"[format_outbox] Claude formatting failed: {result.stderr[:200]}", file=sys.stderr)
+            error_excerpt = summarize_cli_error(result.stderr or "")
+            print(
+                f"[format_outbox] Claude formatting failed (rc={result.returncode}): "
+                f"{error_excerpt}",
+                file=sys.stderr,
+            )
             return fallback_format(raw_content)
 
     except subprocess.TimeoutExpired:

--- a/koan/app/pr_submit.py
+++ b/koan/app/pr_submit.py
@@ -7,6 +7,7 @@ fork detection, PR creation, issue comment).
 
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import List, Optional
@@ -20,6 +21,7 @@ from app.github import detect_parent_repo, run_gh, pr_create
 from app.projects_config import resolve_base_branch
 
 logger = logging.getLogger(__name__)
+_GITHUB_REMOTE_RE = re.compile(r"github\.com[:/]([^/]+)/([^/\s.]+?)(?:\.git)?$")
 
 
 def guess_project_name(project_path: str) -> str:
@@ -43,8 +45,52 @@ def get_commit_subjects(project_path: str, base_branch: str = "main") -> List[st
     return _git_get_commit_subjects(cwd=project_path, base_branch=base_branch)
 
 
-def get_fork_owner(project_path: str) -> str:
-    """Return the GitHub owner login of the current repo."""
+def _get_submit_remote(project_name: str) -> str:
+    """Return submit_to_repository.remote for a project, if configured."""
+    from app.projects_config import load_projects_config, get_project_submit_to_repository
+
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if not koan_root:
+        return ""
+
+    try:
+        config = load_projects_config(koan_root)
+    except (RuntimeError, OSError, subprocess.SubprocessError) as e:
+        logger.debug("Failed to load submit remote config: %s", e)
+        return ""
+
+    if not config:
+        return ""
+
+    submit_cfg = get_project_submit_to_repository(config, project_name)
+    return submit_cfg.get("remote", "")
+
+
+def _parse_owner_from_remote_url(remote_url: str) -> str:
+    """Extract GitHub owner from a git remote URL."""
+    match = _GITHUB_REMOTE_RE.search((remote_url or "").strip())
+    return match.group(1).strip() if match else ""
+
+
+def get_fork_owner(project_path: str, remote: str = "") -> str:
+    """Return GitHub owner login for PR head branch.
+
+    If ``remote`` is provided, owner is inferred from that remote URL first.
+    Falls back to ``gh repo view`` owner lookup.
+    """
+    if remote:
+        try:
+            remote_url = run_git_strict(
+                "remote", "get-url", remote,
+                cwd=project_path, timeout=15,
+            )
+            owner = _parse_owner_from_remote_url(remote_url)
+            if owner:
+                return owner
+        except (RuntimeError, OSError, subprocess.SubprocessError) as e:
+            logger.debug("Failed to get owner from remote '%s': %s", remote, e)
+
+    # Fallback: use gh context owner for the current repo.
     try:
         return run_gh(
             "repo", "view", "--json", "owner", "--jq", ".owner.login",
@@ -166,7 +212,8 @@ def submit_draft_pr(
 
     if target["is_fork"]:
         pr_kwargs["repo"] = target["repo"]
-        fork_owner = get_fork_owner(project_path)
+        submit_remote = _get_submit_remote(project_name)
+        fork_owner = get_fork_owner(project_path, remote=submit_remote)
         if fork_owner:
             pr_kwargs["head"] = f"{fork_owner}:{branch}"
 

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -20,10 +20,13 @@ Package structure:
     provider/__init__.py     — Registry, resolution, convenience functions
 """
 
+import logging
 import os
 import subprocess
 import sys
 from typing import List, Optional
+
+log = logging.getLogger(__name__)
 
 # Re-export base class and constants for convenience
 from app.provider.base import (  # noqa: F401
@@ -199,6 +202,33 @@ def build_full_command(
     )
 
 
+def _raise_cli_invocation_error(stderr: str = "", stdout: str = "") -> None:
+    """Raise RuntimeError with user-facing hints for known CLI failure classes."""
+    from app.cli_errors import build_landlock_hint, is_landlock_failure
+
+    if is_landlock_failure(stdout=stdout, stderr=stderr):
+        log.debug(
+            "[provider] Landlock failure details (stdout=%r, stderr=%r)",
+            stdout[:500] if stdout else "",
+            stderr[:500] if stderr else "",
+        )
+        raise RuntimeError(f"CLI invocation failed: {build_landlock_hint()}")
+
+    # For non-Landlock failures, include both stderr and stdout (when available)
+    # in the error message, truncated to keep the exception message concise.
+    stderr_str = stderr or ""
+    stdout_str = stdout or ""
+
+    message_parts = []
+    if stderr_str.strip():
+        message_parts.append("stderr:\n" + stderr_str.strip())
+    if stdout_str.strip():
+        message_parts.append("stdout:\n" + stdout_str.strip())
+
+    combined_message = " | ".join(message_parts) if message_parts else "no output captured"
+    truncated_message = combined_message[:300]
+
+    raise RuntimeError(f"CLI invocation failed: {truncated_message}")
 def run_command(
     prompt: str,
     project_path: str,
@@ -236,8 +266,9 @@ def run_command(
     )
 
     if result.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {result.stderr[:300]}"
+        _raise_cli_invocation_error(
+            stderr=result.stderr or "",
+            stdout=result.stdout or "",
         )
 
     from app.claude_step import strip_cli_noise
@@ -305,9 +336,7 @@ def run_command_streaming(
 
     stdout_text = "\n".join(lines)
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"CLI invocation failed: {stderr_text[:300]}"
-        )
+        _raise_cli_invocation_error(stderr=stderr_text, stdout=stdout_text)
 
     # Notify user when max turns ceiling was hit so they know how to raise it
     import re

--- a/koan/tests/test_cli_errors.py
+++ b/koan/tests/test_cli_errors.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from app.cli_errors import ErrorCategory, classify_cli_error
+from app.cli_errors import (
+    ErrorCategory,
+    build_landlock_hint,
+    classify_cli_error,
+    is_landlock_failure,
+)
 
 
 class TestClassifyCliError:
@@ -157,3 +162,25 @@ class TestClassifyCliError:
         stderr = "Error: Invalid API key provided. Check your ANTHROPIC_API_KEY."
         result = classify_cli_error(1, stderr=stderr)
         assert result == ErrorCategory.TERMINAL
+
+
+class TestLandlockDetection:
+    """Landlock-specific detection helpers."""
+
+    def test_detects_landlock_restrict_error(self):
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        assert is_landlock_failure(stderr=stderr) is True
+
+    def test_detects_landlock_in_stdout(self):
+        assert is_landlock_failure(stdout="Sandbox(LandlockRestrict)") is True
+
+    def test_returns_false_for_other_errors(self):
+        assert is_landlock_failure(stderr="connection reset by peer") is False
+
+    def test_landlock_hint_mentions_skip_permissions(self):
+        hint = build_landlock_hint()
+        assert "skip_permissions: true" in hint
+        assert "Landlock sandbox initialization failed" in hint

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -1051,13 +1051,42 @@ class TestRunCommand:
     @patch("app.config.get_model_config", return_value={"chat": "sonnet", "fallback": "haiku"})
     def test_failure_raises_runtime_error(self, mock_models, mock_run):
         """Non-zero exit raises RuntimeError with stderr snippet."""
-        mock_run.return_value = MagicMock(returncode=1, stderr="some error message")
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="some error message")
         with pytest.raises(RuntimeError, match="CLI invocation failed"):
             run_command(
                 prompt="analyze this",
                 project_path="/fake/project",
                 allowed_tools=["Read"],
             )
+
+    @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "codex"})
+    @patch("app.cli_exec.run_cli")
+    @patch("app.config.get_model_config", return_value={"chat": "gpt-5-codex", "fallback": ""})
+    def test_landlock_failure_shows_hint_and_logs_raw_error(
+        self, mock_models, mock_run
+    ):
+        """Landlock startup failure gets actionable hint and raw debug output."""
+        stderr = (
+            "error applying legacy Linux sandbox restrictions: "
+            "Sandbox(LandlockRestrict)"
+        )
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr=stderr)
+        with patch("app.provider.log") as mock_log:
+            with pytest.raises(RuntimeError, match="Landlock sandbox initialization failed"):
+                run_command(
+                    prompt="analyze this",
+                    project_path="/fake/project",
+                    allowed_tools=["Read"],
+                )
+            mock_log.debug.assert_called_once()
+            call_args = mock_log.debug.call_args
+            # Verify structured format: format string + positional stdout/stderr args
+            fmt_string = call_args.args[0]
+            assert "stdout=%r" in fmt_string
+            assert "stderr=%r" in fmt_string
+            # Verify the stderr content is passed as the second positional arg (truncated to 500)
+            logged_stderr = call_args.args[2]
+            assert logged_stderr == stderr[:500]
 
     @patch.dict("os.environ", {"KOAN_CLI_PROVIDER": "claude"})
     @patch("app.cli_exec.run_cli")

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -153,10 +153,10 @@ class TestFormatForTelegram:
     def test_prompt_includes_soul_and_prefs(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "my-soul", "my-prefs")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]  # ["claude", "-p", prompt]
-        assert "my-soul" in prompt
-        assert "my-prefs" in prompt
+        cmd = mock_run.call_args[0][0]
+        joined = " ".join(str(x) for x in cmd)
+        assert "my-soul" in joined
+        assert "my-prefs" in joined
 
     @patch("app.cli_exec.run_cli")
     def test_prompt_omits_prefs_when_empty(self, mock_run):
@@ -170,10 +170,10 @@ class TestFormatForTelegram:
     def test_prompt_includes_memory_context(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "prefs", memory_context="Session 61: tests")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]
-        assert "Session 61: tests" in prompt
-        assert "Recent memory context" in prompt
+        cmd = mock_run.call_args[0][0]
+        joined = " ".join(str(x) for x in cmd)
+        assert "Session 61: tests" in joined
+        assert "Recent memory context" in joined
 
     @patch("app.cli_exec.run_cli")
     def test_prompt_omits_memory_when_empty(self, mock_run):

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -12,6 +12,7 @@ from app.format_outbox import (
     load_memory_context,
     format_message,
     fallback_format,
+    summarize_cli_error,
 )
 from app.response_cache import _format_cache
 
@@ -109,6 +110,24 @@ class TestFormatForTelegram:
         # Should use fallback (removes #)
         assert "#" not in result
         assert "Raw content" in result
+
+    @patch("app.cli_exec.run_cli")
+    def test_nonzero_returncode_logs_compact_actionable_error(self, mock_run, capsys):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "OpenAI Codex v0.27.0\n"
+                "model: gpt-5-codex\n"
+                "workspace: /tmp/koan\n"
+                "RuntimeError: permission denied for sandbox profile\n"
+            ),
+        )
+        format_message("raw", "soul", "")
+        captured = capsys.readouterr()
+        assert "rc=1" in captured.err
+        assert "permission denied for sandbox profile" in captured.err
+        assert "OpenAI Codex v0.27.0" not in captured.err
 
     @patch("app.cli_exec.run_cli")
     def test_fallback_on_empty_stdout(self, mock_run):
@@ -259,6 +278,21 @@ class TestGetTimeHint:
             mock_dt.now.return_value = fake
             result = _get_time_hint()
         assert "late night" in result.lower()
+
+
+class TestSummarizeCliError:
+    def test_prefers_keyword_lines_and_removes_noise(self):
+        stderr = (
+            "OpenAI Codex v0.27.0\n"
+            "model: gpt-5-codex\n"
+            "workspace: /tmp/koan\n"
+            "Connection reset by peer\n"
+            "request failed with HTTP 502\n"
+        )
+        summary = summarize_cli_error(stderr)
+        assert "HTTP 502" in summary
+        assert "Connection reset" in summary
+        assert "OpenAI Codex" not in summary
 
 
 class TestFormatOutboxCLI:

--- a/koan/tests/test_pr_submit.py
+++ b/koan/tests/test_pr_submit.py
@@ -78,6 +78,13 @@ class TestGetForkOwner:
     def test_returns_stripped(self, mock):
         assert get_fork_owner("/p") == "myuser"
 
+    @patch(f"{_M}.run_git_strict", return_value="git@github.com:forkuser/repo.git")
+    def test_uses_configured_remote_owner_when_available(self, mock):
+        assert get_fork_owner("/p", remote="myfork") == "forkuser"
+        mock.assert_called_once_with(
+            "remote", "get-url", "myfork", cwd="/p", timeout=15
+        )
+
     @patch(f"{_M}.run_gh", side_effect=RuntimeError("gh not found"))
     def test_error_returns_empty(self, mock):
         assert get_fork_owner("/p") == ""
@@ -181,6 +188,46 @@ class TestSubmitDraftPr:
             kw = mock_pr.call_args[1]
             assert kw["repo"] == "upstream/r"
             assert kw["head"] == "myfork:koan/feat"
+
+    @patch.dict("os.environ", {"KOAN_ROOT": "/koan"})
+    def test_submit_to_repository_repo_and_remote_override(self):
+        config = {
+            "projects": {
+                "proj": {
+                    "path": "/p",
+                    "submit_to_repository": {
+                        "repo": "upstream/repo",
+                        "remote": "fork-remote",
+                    },
+                }
+            }
+        }
+        with patch("app.projects_config.load_projects_config", return_value=config), \
+             patch(f"{_M}.detect_parent_repo", return_value=None), \
+             patch(f"{_M}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_M}.run_gh", return_value=""), \
+             patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
+             patch(f"{_M}.run_git_strict", side_effect=["", "git@github.com:forkuser/repo.git"]), \
+             patch(f"{_M}.pr_create", return_value="https://pr/10") as mock_pr:
+            result = submit_draft_pr("/p", "proj", "owner", "repo", "1", "T", "B")
+            assert result == "https://pr/10"
+            kw = mock_pr.call_args[1]
+            assert kw["repo"] == "upstream/repo"
+            assert kw["head"] == "forkuser:koan/feat"
+
+    @patch.dict("os.environ", {"KOAN_ROOT": ""})
+    def test_fork_parent_auto_detect_fallback(self):
+        with patch(f"{_M}.detect_parent_repo", return_value="upstream/repo"), \
+             patch(f"{_M}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_M}.run_gh", side_effect=["", "forkuser\n"]), \
+             patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
+             patch(f"{_M}.run_git_strict"), \
+             patch(f"{_M}.pr_create", return_value="https://pr/11") as mock_pr:
+            result = submit_draft_pr("/p", "proj", "owner", "repo", "2", "T", "B")
+            assert result == "https://pr/11"
+            kw = mock_pr.call_args[1]
+            assert kw["repo"] == "upstream/repo"
+            assert kw["head"] == "forkuser:koan/feat"
 
     def test_pr_create_failure_returns_none(self):
         with patch(f"{_M}.get_current_branch", return_value="feat"), \


### PR DESCRIPTION
This fork-side consolidation PR bundles the Codex-provider improvements that were previously split across multiple branches.

Included:
- landlock/Codex provider hardening from #18
- formatter fallback noise reduction from #13
- submit_to_repository PR-targeting fix from #9 (submit-path pieces only)
- test alignment for current command-builder shape on main

Intentionally excluded:
- unrelated dashboard/config loading work from #15
- older overlapping Codex/provider file variants where #18 already carried the cleaner implementation

This PR is for fork-side review/staging only for now; not opening upstream yet.
